### PR TITLE
Atualiza pacotes e adiciona testes unitários

### DIFF
--- a/Cowork.Tests/ClienteControllerTest.cs
+++ b/Cowork.Tests/ClienteControllerTest.cs
@@ -1,0 +1,161 @@
+﻿using Cowork.Controllers;
+using Cowork.Data;
+using Cowork.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Cowork.Test
+{
+    public class ClienteControllerTests
+    {
+        private readonly ClienteController _controller;
+        private readonly CoworkContext _context;
+
+        public ClienteControllerTests()
+        {
+            var options = new DbContextOptionsBuilder<CoworkContext>()
+                .UseInMemoryDatabase(databaseName: "TestDatabase")
+                .Options;
+
+            _context = new CoworkContext(options);
+            _controller = new ClienteController(_context);
+
+            // Limpar o banco de dados antes de adicionar dados de teste
+            _context.Clientes.RemoveRange(_context.Clientes);
+            _context.SaveChanges();
+
+            // Seed the database with test data
+            _context.Clientes.AddRange(
+                new Cliente { Id = 1, Nome = "Cliente 1", Email = "cliente1@example.com", Telefone = "123456789" },
+                new Cliente { Id = 2, Nome = "Cliente 2", Email = "cliente2@example.com", Telefone = "987654321" }
+            );
+            _context.SaveChanges();
+        }
+
+        [Fact]
+        public async Task Index_ReturnsViewResult_WithAListOfClientes()
+        {
+            // Act
+            var result = await _controller.Index();
+
+            // Assert
+            var viewResult = Assert.IsType<ViewResult>(result);
+            var model = Assert.IsAssignableFrom<List<Cliente>>(viewResult.Model);
+            Assert.Equal(2, model.Count);
+        }
+
+        [Fact]
+        public async Task Details_ReturnsViewResult_WithCliente()
+        {
+            // Act
+            var result = await _controller.Details(1);
+
+            // Assert
+            var viewResult = Assert.IsType<ViewResult>(result);
+            var model = Assert.IsAssignableFrom<Cliente>(viewResult.Model);
+            Assert.Equal(1, model.Id);
+        }
+
+        [Fact]
+        public void Create_ReturnsViewResult()
+        {
+            // Act
+            var result = _controller.Create();
+
+            // Assert
+            Assert.IsType<ViewResult>(result);
+        }
+
+        [Fact]
+        public async Task Create_Post_ReturnsRedirectToActionResult_WhenModelStateIsValid()
+        {
+            // Arrange
+            var cliente = new Cliente { Id = 3, Nome = "Cliente Teste", Email = "emailteste@example.com", Telefone = "010111011" };
+
+            // Act
+            var result = await _controller.Create(cliente);
+
+            // Assert
+            var redirectToActionResult = Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal("Index", redirectToActionResult.ActionName);
+        }
+
+        [Fact]
+        public async Task Edit_ReturnsViewResult_WithCliente()
+        {
+            // Act
+            var result = await _controller.Edit(1);
+
+            // Assert
+            var viewResult = Assert.IsType<ViewResult>(result);
+            var model = Assert.IsAssignableFrom<Cliente>(viewResult.Model);
+            Assert.Equal(1, model.Id);
+        }
+
+        [Fact]
+        public async Task Edit_Post_ReturnsRedirectToActionResult_WhenModelStateIsValid()
+        {
+            // Arrange
+            var cliente = new Cliente { Id = 1, Nome = "Cliente Editado", Email = "emailteste@example.com", Telefone = "010111011" };
+
+            // Desanexar todas as entidades rastreadas
+            foreach (var entity in _context.ChangeTracker.Entries().ToList())
+            {
+                entity.State = EntityState.Detached;
+            }
+
+            // Buscar a entidade do contexto
+            var clienteToUpdate = await _context.Clientes.AsNoTracking().FirstOrDefaultAsync(c => c.Id == 1);
+
+            if (clienteToUpdate != null)
+            {
+                // Atualizar os valores da entidade
+                clienteToUpdate.Nome = cliente.Nome;
+                clienteToUpdate.Email = cliente.Email;
+                clienteToUpdate.Telefone = cliente.Telefone;
+
+                // Anexar a entidade atualizada e definir seu estado como Modified
+                _context.Attach(clienteToUpdate).State = EntityState.Modified;
+
+                // Act
+                var result = await _controller.Edit(1, clienteToUpdate);
+
+                // Assert
+                var redirectToActionResult = Assert.IsType<RedirectToActionResult>(result);
+                Assert.Equal("Index", redirectToActionResult.ActionName);
+            }
+            else
+            {
+                // Tratar o caso onde clienteToUpdate é nulo
+                Assert.True(false, "Cliente não encontrado para atualização.");
+            }
+        }
+
+
+        [Fact]
+        public async Task Delete_ReturnsViewResult_WithCliente()
+        {
+            // Act
+            var result = await _controller.Delete(1);
+
+            // Assert
+            var viewResult = Assert.IsType<ViewResult>(result);
+            var model = Assert.IsAssignableFrom<Cliente>(viewResult.Model);
+            Assert.Equal(1, model.Id);
+        }
+
+        [Fact]
+        public async Task DeleteConfirmed_ReturnsRedirectToActionResult()
+        {
+            // Act
+            var result = await _controller.DeleteConfirmed(1);
+
+            // Assert
+            var redirectToActionResult = Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal("Index", redirectToActionResult.ActionName);
+        }
+    }
+}

--- a/Cowork.Tests/Cowork.Test.csproj
+++ b/Cowork.Tests/Cowork.Test.csproj
@@ -1,0 +1,39 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Cowork\Cowork.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
+  </ItemGroup>
+
+</Project>

--- a/Cowork.Tests/FuncionarioControllerTest.cs
+++ b/Cowork.Tests/FuncionarioControllerTest.cs
@@ -1,0 +1,159 @@
+﻿using Cowork.Controllers;
+using Cowork.Data;
+using Cowork.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Cowork.Test
+{
+    public class FuncionarioControllerTests
+    {
+        private readonly FuncionarioController _controller;
+        private readonly CoworkContext _context;
+
+        public FuncionarioControllerTests()
+        {
+            var options = new DbContextOptionsBuilder<CoworkContext>()
+                .UseInMemoryDatabase(databaseName: "TestDatabase")
+                .Options;
+
+            _context = new CoworkContext(options);
+            _controller = new FuncionarioController(_context);
+
+            // Limpar o banco de dados antes de adicionar dados de teste
+            _context.Funcionarios.RemoveRange(_context.Funcionarios);
+            _context.SaveChanges();
+
+            // Seed the database with test data
+            _context.Funcionarios.AddRange(
+                new Funcionario { Id = 1, Nome = "Funcionario 1", Cargo = "Cargo 1" },
+                new Funcionario { Id = 2, Nome = "Funcionario 2", Cargo = "Cargo 2" }
+            );
+            _context.SaveChanges();
+        }
+
+        [Fact]
+        public async Task Index_ReturnsViewResult_WithAListOfFuncionarios()
+        {
+            // Act
+            var result = await _controller.Index();
+
+            // Assert
+            var viewResult = Assert.IsType<ViewResult>(result);
+            var model = Assert.IsAssignableFrom<List<Funcionario>>(viewResult.Model);
+            Assert.Equal(2, model.Count);
+        }
+
+        [Fact]
+        public async Task Details_ReturnsViewResult_WithFuncionario()
+        {
+            // Act
+            var result = await _controller.Details(1);
+
+            // Assert
+            var viewResult = Assert.IsType<ViewResult>(result);
+            var model = Assert.IsAssignableFrom<Funcionario>(viewResult.Model);
+            Assert.Equal(1, model.Id);
+        }
+
+        [Fact]
+        public void Create_ReturnsViewResult()
+        {
+            // Act
+            var result = _controller.Create();
+
+            // Assert
+            Assert.IsType<ViewResult>(result);
+        }
+
+        [Fact]
+        public async Task Create_Post_ReturnsRedirectToActionResult_WhenModelStateIsValid()
+        {
+            // Arrange
+            var funcionario = new Funcionario { Id = 3, Nome = "Funcionario Teste", Cargo = "Cargo Teste" };
+
+            // Act
+            var result = await _controller.Create(funcionario);
+
+            // Assert
+            var redirectToActionResult = Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal("Index", redirectToActionResult.ActionName);
+        }
+
+        [Fact]
+        public async Task Edit_ReturnsViewResult_WithFuncionario()
+        {
+            // Act
+            var result = await _controller.Edit(1);
+
+            // Assert
+            var viewResult = Assert.IsType<ViewResult>(result);
+            var model = Assert.IsAssignableFrom<Funcionario>(viewResult.Model);
+            Assert.Equal(1, model.Id);
+        }
+
+        [Fact]
+        public async Task Edit_Post_ReturnsRedirectToActionResult_WhenModelStateIsValid()
+        {
+            // Arrange
+            var funcionario = new Funcionario { Id = 1, Nome = "Funcionario Editado", Cargo = "Cargo Teste" };
+
+            // Desanexar todas as entidades rastreadas
+            foreach (var entity in _context.ChangeTracker.Entries().ToList())
+            {
+                entity.State = EntityState.Detached;
+            }
+
+            // Buscar a entidade do contexto
+            var funcionarioToUpdate = await _context.Funcionarios.AsNoTracking().FirstOrDefaultAsync(f => f.Id == 1);
+
+            if (funcionarioToUpdate != null)
+            {
+                // Atualizar os valores da entidade
+                funcionarioToUpdate.Nome = funcionario.Nome;
+                funcionarioToUpdate.Cargo = funcionario.Cargo;
+
+                // Anexar a entidade atualizada e definir seu estado como Modified
+                _context.Attach(funcionarioToUpdate).State = EntityState.Modified;
+
+                // Act
+                var result = await _controller.Edit(1, funcionarioToUpdate);
+
+                // Assert
+                var redirectToActionResult = Assert.IsType<RedirectToActionResult>(result);
+                Assert.Equal("Index", redirectToActionResult.ActionName);
+            }
+            else
+            {
+                // Tratar o caso onde funcionarioToUpdate é nulo
+                Assert.True(false, "Funcionario não encontrado para atualização.");
+            }
+        }
+
+        [Fact]
+        public async Task Delete_ReturnsViewResult_WithFuncionario()
+        {
+            // Act
+            var result = await _controller.Delete(1);
+
+            // Assert
+            var viewResult = Assert.IsType<ViewResult>(result);
+            var model = Assert.IsAssignableFrom<Funcionario>(viewResult.Model);
+            Assert.Equal(1, model.Id);
+        }
+
+        [Fact]
+        public async Task DeleteConfirmed_ReturnsRedirectToActionResult()
+        {
+            // Act
+            var result = await _controller.DeleteConfirmed(1);
+
+            // Assert
+            var redirectToActionResult = Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal("Index", redirectToActionResult.ActionName);
+        }
+    }
+}

--- a/Cowork.Tests/ReservaControllerTest.cs
+++ b/Cowork.Tests/ReservaControllerTest.cs
@@ -1,0 +1,178 @@
+﻿using Cowork.Controllers;
+using Cowork.Data;
+using Cowork.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Cowork.Test
+{
+    public class ReservaControllerTests : IDisposable
+    {
+        private readonly ReservaController _controller;
+        private readonly CoworkContext _context;
+
+        public ReservaControllerTests()
+        {
+            var options = new DbContextOptionsBuilder<CoworkContext>()
+                .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString()) // Usar um banco de dados em memória único para cada teste
+                .Options;
+
+            _context = new CoworkContext(options);
+            _controller = new ReservaController(_context);
+
+            // Adicionar dados de teste para Clientes e Salas
+            _context.Clientes.AddRange(
+                new Cliente { Id = 1, Nome = "Cliente 1", Email = "cliente1@example.com", Telefone = "123456789" },
+                new Cliente { Id = 2, Nome = "Cliente 2", Email = "cliente2@example.com", Telefone = "987654321" }
+            );
+
+            _context.Salas.AddRange(
+                new Sala { Id = 1, Nome = "Sala 1", Capacidade = 10, PrecoPorHora = 100 },
+                new Sala { Id = 2, Nome = "Sala 2", Capacidade = 20, PrecoPorHora = 200 }
+            );
+
+            _context.SaveChanges();
+
+            // Adicionar dados de teste para Reservas
+            _context.Reservas.AddRange(
+                new Reserva { Id = 1, ClienteId = 1, SalaId = 1, DataReserva = DateTime.Now, HorarioInicio = new TimeSpan(9, 0, 0), HorarioFim = new TimeSpan(10, 0, 0) },
+                new Reserva { Id = 2, ClienteId = 2, SalaId = 2, DataReserva = DateTime.Now, HorarioInicio = new TimeSpan(10, 0, 0), HorarioFim = new TimeSpan(11, 0, 0) }
+            );
+            _context.SaveChanges();
+        }
+
+        public void Dispose()
+        {
+            _context.Dispose();
+        }
+
+        [Fact]
+        public async Task Index_ReturnsViewResult_WithAListOfReservas()
+        {
+            // Act
+            var result = await _controller.Index();
+
+            // Assert
+            var viewResult = Assert.IsType<ViewResult>(result);
+            var model = Assert.IsAssignableFrom<List<Reserva>>(viewResult.Model);
+            Assert.Equal(2, model.Count);
+        }
+
+        [Fact]
+        public void Create_ReturnsViewResult()
+        {
+            // Act
+            var result = _controller.Create();
+
+            // Assert
+            Assert.IsType<ViewResult>(result);
+        }
+
+        [Fact]
+        public async Task Create_Post_ReturnsRedirectToActionResult_WhenModelStateIsValid()
+        {
+            // Arrange
+            var reserva = new Reserva { Id = 3, ClienteId = 1, SalaId = 1, DataReserva = DateTime.Now, HorarioInicio = new TimeSpan(11, 0, 0), HorarioFim = new TimeSpan(12, 0, 0) };
+
+            // Act
+            var result = await _controller.Create(reserva);
+
+            // Assert
+            var redirectToActionResult = Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal("Index", redirectToActionResult.ActionName);
+        }
+
+        [Fact]
+        public async Task Details_ReturnsViewResult_WithReserva()
+        {
+            // Act
+            var result = await _controller.Details(1);
+
+            // Assert
+            var viewResult = Assert.IsType<ViewResult>(result);
+            var model = Assert.IsAssignableFrom<Reserva>(viewResult.ViewData.Model);
+            Assert.Equal(1, model.Id);
+        }
+
+        [Fact]
+        public async Task Edit_ReturnsViewResult_WithReserva()
+        {
+            // Act
+            var result = await _controller.Edit(1);
+
+            // Assert
+            var viewResult = Assert.IsType<ViewResult>(result);
+            var model = Assert.IsAssignableFrom<Reserva>(viewResult.ViewData.Model);
+            Assert.Equal(1, model.Id);
+        }
+
+        [Fact]
+        public async Task Edit_Post_ReturnsRedirectToActionResult_WhenModelStateIsValid()
+        {
+            // Arrange
+            var reserva = new Reserva { Id = 1, ClienteId = 1, SalaId = 1, DataReserva = DateTime.Now, HorarioInicio = new TimeSpan(9, 0, 0), HorarioFim = new TimeSpan(11, 0, 0) };
+
+            // Desanexar todas as entidades rastreadas
+            foreach (var entity in _context.ChangeTracker.Entries().ToList())
+            {
+                entity.State = EntityState.Detached;
+            }
+
+            // Buscar a entidade do contexto
+            var reservaToUpdate = await _context.Reservas.AsNoTracking().FirstOrDefaultAsync(r => r.Id == 1);
+
+            if (reservaToUpdate != null)
+            {
+                // Atualizar os valores da entidade
+                reservaToUpdate.ClienteId = reserva.ClienteId;
+                reservaToUpdate.SalaId = reserva.SalaId;
+                reservaToUpdate.DataReserva = reserva.DataReserva;
+                reservaToUpdate.HorarioInicio = reserva.HorarioInicio;
+                reservaToUpdate.HorarioFim = reserva.HorarioFim;
+
+                // Anexar a entidade atualizada e definir seu estado como Modified
+                _context.Attach(reservaToUpdate).State = EntityState.Modified;
+
+                // Act
+                var result = await _controller.Edit(1, reservaToUpdate);
+
+                // Assert
+                var redirectToActionResult = Assert.IsType<RedirectToActionResult>(result);
+                Assert.Equal("Index", redirectToActionResult.ActionName);
+            }
+            else
+            {
+                // Tratar o caso onde reservaToUpdate é nulo
+                Assert.True(false, "Reserva não encontrada para atualização.");
+            }
+        }
+
+        [Fact]
+        public async Task Delete_ReturnsViewResult_WithReserva()
+        {
+            // Act
+            var result = await _controller.Delete(1);
+
+            // Assert
+            var viewResult = Assert.IsType<ViewResult>(result);
+            var model = Assert.IsAssignableFrom<Reserva>(viewResult.ViewData.Model);
+            Assert.Equal(1, model.Id);
+        }
+
+        [Fact]
+        public async Task DeleteConfirmed_DeletesReserva_AndRedirects()
+        {
+            // Act
+            var result = await _controller.DeleteConfirmed(1);
+
+            // Assert
+            var redirectToActionResult = Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal("Index", redirectToActionResult.ActionName);
+            Assert.Null(await _context.Reservas.FindAsync(1));
+        }
+    }
+}

--- a/Cowork.Tests/SalaControllerTest.cs
+++ b/Cowork.Tests/SalaControllerTest.cs
@@ -1,0 +1,158 @@
+﻿using Cowork.Controllers;
+using Cowork.Data;
+using Cowork.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Cowork.Test
+{
+    public class SalaControllerTests
+    {
+        private readonly SalaController _controller;
+        private readonly CoworkContext _context;
+
+        public SalaControllerTests()
+        {
+            var options = new DbContextOptionsBuilder<CoworkContext>()
+                .UseInMemoryDatabase(databaseName: "TestDatabase")
+                .Options;
+
+            _context = new CoworkContext(options);
+            _controller = new SalaController(_context);
+
+            // Limpar o banco de dados antes de adicionar dados de teste
+            _context.Salas.RemoveRange(_context.Salas);
+            _context.SaveChanges();
+
+            // Seed the database with test data
+            _context.Salas.AddRange(
+                new Sala { Id = 1, Nome = "Sala 1" },
+                new Sala { Id = 2, Nome = "Sala 2" }
+            );
+            _context.SaveChanges();
+        }
+
+        [Fact]
+        public async Task Index_ReturnsViewResult_WithAListOfSalas()
+        {
+            // Act
+            var result = await _controller.Index();
+
+            // Assert
+            var viewResult = Assert.IsType<ViewResult>(result);
+            var model = Assert.IsAssignableFrom<List<Sala>>(viewResult.Model);
+            Assert.Equal(2, model.Count);
+        }
+
+        [Fact]
+        public async Task Details_ReturnsViewResult_WithSala()
+        {
+            // Act
+            var result = await _controller.Details(1);
+
+            // Assert
+            var viewResult = Assert.IsType<ViewResult>(result);
+            var model = Assert.IsAssignableFrom<Sala>(viewResult.Model);
+            Assert.Equal(1, model.Id);
+        }
+
+        [Fact]
+        public void Create_ReturnsViewResult()
+        {
+            // Act
+            var result = _controller.Create();
+
+            // Assert
+            Assert.IsType<ViewResult>(result);
+        }
+
+        [Fact]
+        public async Task Create_Post_ReturnsRedirectToActionResult_WhenModelStateIsValid()
+        {
+            // Arrange
+            var sala = new Sala { Id = 3, Nome = "Sala Teste" };
+
+            // Act
+            var result = await _controller.Create(sala);
+
+            // Assert
+            var redirectToActionResult = Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal("Index", redirectToActionResult.ActionName);
+        }
+
+        [Fact]
+        public async Task Edit_ReturnsViewResult_WithSala()
+        {
+            // Act
+            var result = await _controller.Edit(1);
+
+            // Assert
+            var viewResult = Assert.IsType<ViewResult>(result);
+            var model = Assert.IsAssignableFrom<Sala>(viewResult.Model);
+            Assert.Equal(1, model.Id);
+        }
+
+        [Fact]
+        public async Task Edit_Post_ReturnsRedirectToActionResult_WhenModelStateIsValid()
+        {
+            // Arrange
+            var sala = new Sala { Id = 1, Nome = "Sala Editada" };
+
+            // Desanexar todas as entidades rastreadas
+            foreach (var entity in _context.ChangeTracker.Entries().ToList())
+            {
+                entity.State = EntityState.Detached;
+            }
+
+            // Buscar a entidade do contexto
+            var salaToUpdate = await _context.Salas.AsNoTracking().FirstOrDefaultAsync(s => s.Id == 1);
+
+            if (salaToUpdate != null)
+            {
+                // Atualizar os valores da entidade
+                salaToUpdate.Nome = sala.Nome;
+
+                // Anexar a entidade atualizada e definir seu estado como Modified
+                _context.Attach(salaToUpdate).State = EntityState.Modified;
+
+                // Act
+                var result = await _controller.Edit(1, salaToUpdate);
+
+                // Assert
+                var redirectToActionResult = Assert.IsType<RedirectToActionResult>(result);
+                Assert.Equal("Index", redirectToActionResult.ActionName);
+            }
+            else
+            {
+                // Tratar o caso onde salaToUpdate é nulo
+                Assert.True(false, "Sala não encontrada para atualização.");
+            }
+        }
+        [Fact]
+        public async Task Delete_ReturnsViewResult_WithSala()
+        {
+            // Act
+            var result = await _controller.Delete(1);
+
+            // Assert
+            var viewResult = Assert.IsType<ViewResult>(result);
+            var model = Assert.IsAssignableFrom<Sala>(viewResult.Model);
+            Assert.Equal(1, model.Id);
+        }
+
+        [Fact]
+        public async Task DeleteConfirmed_ReturnsRedirectToActionResult()
+        {
+            // Act
+            var result = await _controller.DeleteConfirmed(1);
+
+            // Assert
+            var redirectToActionResult = Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal("Index", redirectToActionResult.ActionName);
+        }
+    }
+}

--- a/Cowork.Tests/ValorTotalTest.cs
+++ b/Cowork.Tests/ValorTotalTest.cs
@@ -1,0 +1,28 @@
+﻿using Cowork.Models;
+using System;
+using Xunit;
+
+namespace Cowork.Test
+{
+    public class ValorTotalTests
+    {
+        [Fact]
+        public void ValorTotal_CalculatesCorrectly()
+        {
+            // Arrange
+            var sala = new Sala { PrecoPorHora = 100 };
+            var reserva = new Reserva
+            {
+                Sala = sala,
+                HorarioInicio = new TimeSpan(9, 0, 0),
+                HorarioFim = new TimeSpan(11, 0, 0)
+            };
+
+            // Act
+            var valorTotal = reserva.ValorTotal;
+
+            // Assert
+            Assert.Equal(200, valorTotal);
+        }
+    }
+}

--- a/Cowork/Cowork.csproj
+++ b/Cowork/Cowork.csproj
@@ -16,13 +16,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.8">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.5" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CoworkingSys.sln
+++ b/CoworkingSys.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.10.35027.167
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cowork", "Cowork\Cowork.csproj", "{4A97B46F-9535-4517-8477-016367CC6EA7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cowork.Test", "Cowork.Tests\Cowork.Test.csproj", "{846597C1-6375-4C35-9B04-A0C14B96378A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{4A97B46F-9535-4517-8477-016367CC6EA7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4A97B46F-9535-4517-8477-016367CC6EA7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4A97B46F-9535-4517-8477-016367CC6EA7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{846597C1-6375-4C35-9B04-A0C14B96378A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{846597C1-6375-4C35-9B04-A0C14B96378A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{846597C1-6375-4C35-9B04-A0C14B96378A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{846597C1-6375-4C35-9B04-A0C14B96378A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Atualização das referências de pacotes no arquivo `Cowork.csproj` para versões mais recentes do Entity Framework Core e Microsoft Visual Studio Web Code Generation Design.

Adição de um novo projeto de testes `Cowork.Test` ao arquivo de solução `CoworkingSys.sln`.

Criação de testes unitários para os controladores `ClienteController`, `FuncionarioController`, `ReservaController` e `SalaController`.

Criação de testes unitários para a propriedade `ValorTotal` da classe `Reserva` no arquivo `ValorTotalTest.cs`.